### PR TITLE
Initial draft for the Phoenix chart 

### DIFF
--- a/phoenix/.helmignore
+++ b/phoenix/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/phoenix/Chart.yaml
+++ b/phoenix/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: phoenix
+description: Next generation frontend for ownCloud
+type: application
+version: 0.1.0
+appVersion: 0.9.0
+home: https://phoenix.owncloud.com
+source: https://github.com/owncloud/phoenix

--- a/phoenix/templates/_helpers.tpl
+++ b/phoenix/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "phoenix.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "phoenix.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "phoenix.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "phoenix.labels" -}}
+helm.sh/chart: {{ include "phoenix.chart" . }}
+{{ include "phoenix.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "phoenix.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "phoenix.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "phoenix.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "phoenix.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/phoenix/templates/deployment.yaml
+++ b/phoenix/templates/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "phoenix.fullname" . }}
+  labels:
+    {{- include "phoenix.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "phoenix.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "phoenix.selectorLabels" . | nindent 8 }}
+    spec:
+      initContainers:
+        - name: config-gen
+          image: busybox
+          command: ['sh', '-c', 'cp /phoenix/config.json /etc/phoenix/']
+          volumeMounts:
+            - name: {{ include "phoenix.fullname" . }}-init-config
+              mountPath: /phoenix/config.json
+              subPath: config.json
+            - name: {{ include "phoenix.fullname" . }}-config
+              mountPath: /etc/phoenix
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: {{ include "phoenix.fullname" . }}-config
+              mountPath: /srv/www/config.json
+              subPath: config.json
+      volumes:
+        - name: {{ include "phoenix.fullname" . }}-config
+          emptyDir: {}
+        - name: {{ include "phoenix.fullname" . }}-init-config
+          configMap:
+            name: phoenix-init-config

--- a/phoenix/templates/phoenix-config.yaml
+++ b/phoenix/templates/phoenix-config.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "phoenix.fullname" . }}-init-config
+  labels:
+    {{- include "phoenix.labels" . | nindent 4 }}
+data:
+  config.json: |
+    {
+      "__doc": "install https://github.com/owncloud/ocis-phoenix, then run this with `./ocis-phoenix-testing-linux-amd64 server --http-addr localhost:8300 --config-file phoenix.oidc.config.json --log-level debug`",
+      "server": "{{ .Values.ocis.server }}",
+      "theme": "owncloud",
+      "version": "{{ .Chart.AppVersion }}",
+      "openIdConnect": {
+        "authority": "{{ .Values.oidc.authority }}",
+        "client_id": "phoenix",
+        "response_type": "code",
+        "scope": "openid profile email"
+      },
+      "apps": {{ .Values.apps | toJson }}
+    }
+

--- a/phoenix/templates/service.yaml
+++ b/phoenix/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "phoenix.fullname" . }}
+  labels:
+    {{- include "phoenix.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "phoenix.selectorLabels" . | nindent 4 }}

--- a/phoenix/values.yaml
+++ b/phoenix/values.yaml
@@ -1,0 +1,21 @@
+replicaCount: 1
+
+image:
+  repository: owncloud/phoenix
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  port: 8300
+
+ocis:
+  server: http://localhost:20080
+
+oidc:
+  authority: http://localhost:20080
+
+apps:
+  - files
+  - markdown-editor
+  - pdf-viewer
+  - media-viewer


### PR DESCRIPTION
## ~Enabling GitHub Actions to publish the charts in [owncloud.github.io/charts](https://owncloud.github.io/charts)~

~GitHub Actions and Pages are a really lightweight way to keep a helm repo in sync with the chart definitions living inside it. Some required steps before merge:~

- [x] ~Push a placeholder [`gh-pages`](https://github.com/owncloud/charts/tree/gh-pages) branch to the repo~
- [x] ~Create a `CR_TOKEN` [secret in settings](https://github.com/owncloud/charts/settings/secrets), holding a [token with push access](https://github.com/settings/tokens/new) to the repo as value.~

~You can see it already in action in:~
- ~https://github.com/cs3org/charts/pull/1~
- ~https://github.com/sciencemesh/charts/pull/1~

### Installing the repo and deploying the Chart:

```console
$ helm repo add owncloud https://owncloud.github.io/helm-charts/
"owncloud" has been added to your repositories

$ helm install phoenix owncloud/phoenix
```

## Decide on how to populate the Phoenix `ConfigMap` 

The most important part of this PR is deciding on the way to provide parameters to configure Phoenix. I used [`phoenix.oidc.config.json`](https://github.com/cs3org/reva/blob/master/examples/oc-phoenix/phoenix.oidc.config.json) as inspiration for the template and left these values configurable:

```yaml
ocis:
  server: http://localhost:20080

oidc:
  authority: http://localhost:20080

apps:
  - files
  - markdown-editor
  - pdf-viewer
  - media-viewer
```

We have had a similar discussion for https://github.com/sciencemesh/sciencemesh/issues/117 for reva. In that case, we're going to go with an embedded tomlfile in the custom vars file defining the different files (see https://github.com/cs3org/charts/pull/2). I need more context on Phoenix to determine which is the best solution here. 

Also, I've just read in https://owncloud.github.io/clients/web/backend-ocis/#setting-up-phoenix: 

> Please note that config.json is generated by `ocis-phoenix` so there is no need to create one.

So It might be a good idea to run `ocis-phoenix` as Phoenix' `init-container` to generate the config and mount it on a shared volume. Provided it can be easily parametrized. (e.g. provide a comma-separated list of apps to install, the authority EP, etc)

- [ ] Decide on a flexible solution for configuring the Phoenix deployment. 

## Remaining issues 

- [ ] For now, I've left the `tag: latest` in `values.yaml` since Phoenix' images just keep that tag, but a release string would be better -> https://github.com/owncloud/phoenix/issues/3481

Keeping this PR as draft until these items get discussed. 